### PR TITLE
Fix the redirect to the /Catalog page on a DeepLinkRequest launch. Ch…

### DIFF
--- a/src/Pages/Catalog.cshtml.cs
+++ b/src/Pages/Catalog.cshtml.cs
@@ -147,7 +147,7 @@ namespace AdvantageTool.Pages
             var credentials = PemHelper.SigningCredentialsFromPemString(platform.PrivateKey);
             var jwt = handler.WriteToken(new JwtSecurityToken(new JwtHeader(credentials), response));
 
-            return Post("id_token", jwt, LtiRequest.DeepLinkingSettings.DeepLinkReturnUrl);
+            return Post("JWT", jwt, LtiRequest.DeepLinkingSettings.DeepLinkReturnUrl);
         }
 
         /// <summary>

--- a/src/Pages/Tool.cshtml.cs
+++ b/src/Pages/Tool.cshtml.cs
@@ -212,7 +212,7 @@ namespace AdvantageTool.Pages
 
             if (messageType == Constants.Lti.LtiDeepLinkingRequestMessageType)
             {
-                return Post("./Catalog", new { idToken });
+                return Post("/Catalog", new { idToken });
             }
 
             IdToken = idToken;


### PR DESCRIPTION
…ange the token parameter name sent back to the Platform when assigning deeplinks to the standard "JWT" as defined in the spec at https://www.imsglobal.org/spec/security/v1p0/#form-parameter